### PR TITLE
cmd/commands: add PostgresSQL DB port, statement_cache_mode config opt

### DIFF
--- a/cmd/commands/migrate.go
+++ b/cmd/commands/migrate.go
@@ -17,12 +17,13 @@ import (
 func runMigrateCommand() error {
 	cfg := struct {
 		Postgres struct {
-			User     string `conf:"default:postgres"`
-			Password string `conf:"default:postgres,mask"`
-			Host     string `conf:"default:postgres"`
-			Name     string `conf:"default:postgres,env:POSTGRES_DB"`
-			Port     int    `conf:"default:5432"`
-			SSLMode  string `conf:"default:prefer"`
+			User               string `conf:"default:postgres"`
+			Password           string `conf:"default:postgres,mask"`
+			Host               string `conf:"default:postgres"`
+			Name               string `conf:"default:postgres,env:POSTGRES_DB"`
+			Port               int    `conf:"default:5432"`
+			SSLMode            string `conf:"default:prefer"`
+			StatementCacheMode string `conf:"default:prepare"`
 		}
 		Args conf.Args
 	}{}
@@ -39,6 +40,7 @@ func runMigrateCommand() error {
 	q := make(url.Values)
 	q.Set("sslmode", cfg.Postgres.SSLMode)
 	q.Set("timezone", "utc")
+	q.Set("statement_cache_mode", cfg.Postgres.StatementCacheMode)
 	u := url.URL{
 		Scheme:   "postgres",
 		User:     url.UserPassword(cfg.Postgres.User, cfg.Postgres.Password),

--- a/cmd/commands/migrate.go
+++ b/cmd/commands/migrate.go
@@ -21,6 +21,7 @@ func runMigrateCommand() error {
 			Password string `conf:"default:postgres,mask"`
 			Host     string `conf:"default:postgres"`
 			Name     string `conf:"default:postgres,env:POSTGRES_DB"`
+			Port     int    `conf:"default:5432"`
 			SSLMode  string `conf:"default:prefer"`
 		}
 		Args conf.Args
@@ -41,7 +42,7 @@ func runMigrateCommand() error {
 	u := url.URL{
 		Scheme:   "postgres",
 		User:     url.UserPassword(cfg.Postgres.User, cfg.Postgres.Password),
-		Host:     cfg.Postgres.Host,
+		Host:     cfg.Postgres.Host + ":" + strconv.Itoa(cfg.Postgres.Port),
 		Path:     cfg.Postgres.Name,
 		RawQuery: q.Encode(),
 	}

--- a/cmd/commands/serve.go
+++ b/cmd/commands/serve.go
@@ -91,14 +91,15 @@ func Serve() error {
 			APIHost         string        `conf:"default:0.0.0.0:3000"`
 		}
 		Postgres struct {
-			User         string `conf:"default:postgres"`
-			Password     string `conf:"default:postgres,mask"`
-			Host         string `conf:"default:postgres"`
-			Name         string `conf:"default:postgres,env:POSTGRES_DB"`
-			Port         int    `conf:"default:5432`
-			MaxIdleConns int    `conf:"default:3"`
-			MaxOpenConns int    `conf:"default:3"`
-			SSLMode      string `conf:"default:disable"`
+			User               string `conf:"default:postgres"`
+			Password           string `conf:"default:postgres,mask"`
+			Host               string `conf:"default:postgres"`
+			Name               string `conf:"default:postgres,env:POSTGRES_DB"`
+			Port               int    `conf:"default:5432`
+			MaxIdleConns       int    `conf:"default:3"`
+			MaxOpenConns       int    `conf:"default:3"`
+			SSLMode            string `conf:"default:disable"`
+			StatementCacheMode string `conf:"default:prepare"`
 		}
 		Redis struct {
 			Addr     string `conf:"default:redis:6379"` // "/var/run/redis/redis.sock"
@@ -146,14 +147,15 @@ func Serve() error {
 
 	// Database
 	dbConn, err := server.OpenDB(server.DBConfig{
-		User:         cfg.Postgres.User,
-		Password:     cfg.Postgres.Password,
-		Host:         cfg.Postgres.Host,
-		Name:         cfg.Postgres.Name,
-		Port:         cfg.Postgres.Port,
-		MaxIdleConns: cfg.Postgres.MaxIdleConns,
-		MaxOpenConns: cfg.Postgres.MaxOpenConns,
-		SSLMode:      cfg.Postgres.SSLMode,
+		User:               cfg.Postgres.User,
+		Password:           cfg.Postgres.Password,
+		Host:               cfg.Postgres.Host,
+		Name:               cfg.Postgres.Name,
+		Port:               cfg.Postgres.Port,
+		MaxIdleConns:       cfg.Postgres.MaxIdleConns,
+		MaxOpenConns:       cfg.Postgres.MaxOpenConns,
+		SSLMode:            cfg.Postgres.SSLMode,
+		StatementCacheMode: cfg.Postgres.StatementCacheMode,
 	})
 	if err != nil {
 		return fmt.Errorf("connecting to db: %w", err)

--- a/cmd/commands/serve.go
+++ b/cmd/commands/serve.go
@@ -95,6 +95,7 @@ func Serve() error {
 			Password     string `conf:"default:postgres,mask"`
 			Host         string `conf:"default:postgres"`
 			Name         string `conf:"default:postgres,env:POSTGRES_DB"`
+			Port         int    `conf:"default:5432`
 			MaxIdleConns int    `conf:"default:3"`
 			MaxOpenConns int    `conf:"default:3"`
 			SSLMode      string `conf:"default:disable"`
@@ -149,6 +150,7 @@ func Serve() error {
 		Password:     cfg.Postgres.Password,
 		Host:         cfg.Postgres.Host,
 		Name:         cfg.Postgres.Name,
+		Port:         cfg.Postgres.Port,
 		MaxIdleConns: cfg.Postgres.MaxIdleConns,
 		MaxOpenConns: cfg.Postgres.MaxOpenConns,
 		SSLMode:      cfg.Postgres.SSLMode,

--- a/cmd/commands/user.go
+++ b/cmd/commands/user.go
@@ -43,6 +43,7 @@ func runUserCommand(command func(dbConn *sqlx.DB, args conf.Args) error) error {
 			Password string `conf:"default:postgres,mask"`
 			Host     string `conf:"default:postgres"`
 			Name     string `conf:"default:postgres,env:POSTGRES_DB"`
+			Port     int `conf:"default:5432"`
 			SSLMode  string `conf:"default:prefer"`
 		}
 		Args conf.Args
@@ -61,6 +62,7 @@ func runUserCommand(command func(dbConn *sqlx.DB, args conf.Args) error) error {
 		User:         cfg.Postgres.User,
 		Password:     cfg.Postgres.Password,
 		Host:         cfg.Postgres.Host,
+		Port:         cfg.Postgres.Port,
 		Name:         cfg.Postgres.Name,
 		MaxIdleConns: 1,
 		MaxOpenConns: 1,

--- a/cmd/commands/user.go
+++ b/cmd/commands/user.go
@@ -39,12 +39,13 @@ type Account struct {
 func runUserCommand(command func(dbConn *sqlx.DB, args conf.Args) error) error {
 	cfg := struct {
 		Postgres struct {
-			User     string `conf:"default:postgres"`
-			Password string `conf:"default:postgres,mask"`
-			Host     string `conf:"default:postgres"`
-			Name     string `conf:"default:postgres,env:POSTGRES_DB"`
-			Port     int `conf:"default:5432"`
-			SSLMode  string `conf:"default:prefer"`
+			User               string `conf:"default:postgres"`
+			Password           string `conf:"default:postgres,mask"`
+			Host               string `conf:"default:postgres"`
+			Name               string `conf:"default:postgres,env:POSTGRES_DB"`
+			Port               int `conf:"default:5432"`
+			SSLMode            string `conf:"default:prefer"`
+			StatementCacheMode string `conf:"default:prepare"`
 		}
 		Args conf.Args
 	}{}
@@ -59,14 +60,15 @@ func runUserCommand(command func(dbConn *sqlx.DB, args conf.Args) error) error {
 	}
 	// Database
 	dbConn, err := server.OpenDB(server.DBConfig{
-		User:         cfg.Postgres.User,
-		Password:     cfg.Postgres.Password,
-		Host:         cfg.Postgres.Host,
-		Port:         cfg.Postgres.Port,
-		Name:         cfg.Postgres.Name,
-		MaxIdleConns: 1,
-		MaxOpenConns: 1,
-		SSLMode:      cfg.Postgres.SSLMode,
+		User:               cfg.Postgres.User,
+		Password:           cfg.Postgres.Password,
+		Host:               cfg.Postgres.Host,
+		Port:               cfg.Postgres.Port,
+		Name:               cfg.Postgres.Name,
+		MaxIdleConns:       1,
+		MaxOpenConns:       1,
+		SSLMode:            cfg.Postgres.SSLMode,
+		StatementCacheMode: cfg.Postgres.StatementCacheMode,
 	})
 	if err != nil {
 		return fmt.Errorf("connecting to db: %w", err)

--- a/internal/server/db.go
+++ b/internal/server/db.go
@@ -12,20 +12,22 @@ import (
 
 // Config is the required properties to use the database.
 type DBConfig struct {
-	User         string
-	Password     string
-	Host         string
-	Name         string
-	Port         int
-	MaxIdleConns int
-	MaxOpenConns int
-	SSLMode      string
+	User               string
+	Password           string
+	Host               string
+	Name               string
+	Port               int
+	MaxIdleConns       int
+	MaxOpenConns       int
+	SSLMode            string
+	StatementCacheMode string
 }
 
 func OpenDB(cfg DBConfig) (*sqlx.DB, error) {
 	q := make(url.Values)
 	q.Set("sslmode", cfg.SSLMode)
 	q.Set("timezone", "utc")
+	q.Set("statement_cache_mode", cfg.StatementCacheMode)
 
 	u := url.URL{
 		Scheme:   "postgres",

--- a/internal/server/db.go
+++ b/internal/server/db.go
@@ -3,6 +3,7 @@ package server
 // Code from https://github.com/ardanlabs/service/blob/master/business/sys/database/database.go
 
 import (
+	"strconv"
 	"net/url"
 
 	"github.com/jmoiron/sqlx"
@@ -15,6 +16,7 @@ type DBConfig struct {
 	Password     string
 	Host         string
 	Name         string
+	Port         int
 	MaxIdleConns int
 	MaxOpenConns int
 	SSLMode      string
@@ -28,7 +30,7 @@ func OpenDB(cfg DBConfig) (*sqlx.DB, error) {
 	u := url.URL{
 		Scheme:   "postgres",
 		User:     url.UserPassword(cfg.User, cfg.Password),
-		Host:     cfg.Host,
+		Host:     cfg.Host + ":" + strconv.Itoa(cfg.Port),
 		Path:     cfg.Name,
 		RawQuery: q.Encode(),
 	}


### PR DESCRIPTION
~I tried to deploy GISQUICK web application on the Digital Ocean Kubernetes k8 with success. It would be usefull if some of the configuration settings options were retrieved from the ENV vars.~

