### PR TITLE
Add project bookmarks

### DIFF
--- a/internal/application/projects.go
+++ b/internal/application/projects.go
@@ -528,6 +528,31 @@ func GetTableFields(lm domain.LayerMeta, ls domain.LayerSettings) domain.StringA
 	return fields
 }
 
+func GetBookmarks(meta domain.QgisMeta, settings domain.ProjectSettings) (map[string]map[string]interface{}) {
+	bookmarks := make(map[string]map[string]interface{})
+	for groupName, group := range meta.Bookmarks {
+		bookmarks[groupName] = make(map[string]interface{})
+		groupSettings, groupHasSettings := settings.Bookmarks[groupName]
+		for id, bookmark := range group {
+			transformedBookmark := make(map[string]interface{})
+			transformedBookmark["id"] = bookmark.Id
+			transformedBookmark["name"] = bookmark.Name
+			transformedBookmark["extent"] = bookmark.Extent
+			transformedBookmark["rotation"] = bookmark.Rotation
+			transformedBookmark["group"] = bookmark.Group
+
+			if groupHasSettings {
+				bookmarkSettings, bookmarkHasSettings := groupSettings[id]
+				if bookmarkHasSettings && bookmarkSettings.Content != "" {
+					transformedBookmark["content"] = bookmarkSettings.Content
+				}
+			}
+			bookmarks[groupName][id] = transformedBookmark
+		}
+	}
+	return bookmarks
+}
+
 func (s *projectService) GetProjectCustomizations(projectName string) (json.RawMessage, error) {
 	return s.repo.GetProjectCustomizations(projectName)
 }
@@ -766,6 +791,7 @@ func (s *projectService) GetMapConfig(projectName string, user domain.User) (map
 	data["name"] = projectName
 	data["ows_url"] = fmt.Sprintf("/api/map/ows/%s", projectName)
 	data["ows_project"] = projectName
+	data["bookmarks"] = GetBookmarks(meta, settings)
 
 	topics := make([]domain.Topic, 0)
 

--- a/internal/domain/project_meta.go
+++ b/internal/domain/project_meta.go
@@ -61,22 +61,31 @@ type LayerAttribute struct {
 	Format     string                 `json:"format,omitempty"`
 }
 
+type BookmarkMeta struct {
+	Id       string    `json:"id"`
+	Name     string    `json:"name"`
+	Extent   []float64 `json:"extent"`
+	Rotation float64   `json:"rotation"`
+	Group    string    `json:"group"`
+}
+
 type QgisMeta struct {
 	File   string    `json:"file"`
 	Title  string    `json:"title"`
 	Extent []float64 `json:"extent"`
 	Scales []float64 `json:"scales"`
-	// LayersTree        []TreeNode             `json:"layers_tree"`
-	LayersTree        []interface{}          `json:"layers_tree"`
-	LayersOrder       []string               `json:"layers_order"`
-	BaseLayers        []string               `json:"base_layers"`
-	Layers            map[string]LayerMeta   `json:"layers"`
-	Projection        string                 `json:"projection"`
-	Projections       map[string]*Projection `json:"projections"`
-	Units             map[string]interface{} `json:"units"`
-	ComposerTemplates []interface{}          `json:"composer_templates"`
-	Client            map[string]interface{} `json:"client_info"`
-	ProjectHash       string                 `json:"project_hash"`
+	// LayersTree        []TreeNode                      `json:"layers_tree"`
+	LayersTree        []interface{}                      `json:"layers_tree"`
+	LayersOrder       []string                           `json:"layers_order"`
+	BaseLayers        []string                           `json:"base_layers"`
+	Layers            map[string]LayerMeta               `json:"layers"`
+	Projection        string                             `json:"projection"`
+	Projections       map[string]*Projection             `json:"projections"`
+	Units             map[string]interface{}             `json:"units"`
+	ComposerTemplates []interface{}                      `json:"composer_templates"`
+	Client            map[string]interface{}             `json:"client_info"`
+	ProjectHash       string                             `json:"project_hash"`
+	Bookmarks         map[string]map[string]BookmarkMeta `json:"bookmarks"`
 }
 
 type TreeNode interface {

--- a/internal/domain/project_settings.go
+++ b/internal/domain/project_settings.go
@@ -58,16 +58,17 @@ type Authentication struct {
 }
 
 type ProjectSettings struct {
-	Auth            Authentication           `json:"auth"` // or access?
-	BaseLayers      []string                 `json:"base_layers"`
-	Layers          map[string]LayerSettings `json:"layers"`
-	Title           string                   `json:"title"`
-	MapCache        bool                     `json:"use_mapcache"`
-	Topics          []Topic                  `json:"topics"`
-	Extent          []float64                `json:"extent"`
-	InitialExtent   []float64                `json:"initial_extent"`
-	Scales          json.RawMessage          `json:"scales"`
-	TileResolutions []float64                `json:"tile_resolutions"`
-	Formatters      []json.RawMessage        `json:"formatters,omitempty"`
-	Proj4           map[string]string        `json:"proj4,omitempty"`
+	Auth            Authentication                 `json:"auth"` // or access?
+	BaseLayers      []string                       `json:"base_layers"`
+	Layers          map[string]LayerSettings       `json:"layers"`
+	Title           string                         `json:"title"`
+	MapCache        bool                           `json:"use_mapcache"`
+	Topics          []Topic                        `json:"topics"`
+	Extent          []float64                      `json:"extent"`
+	InitialExtent   []float64                      `json:"initial_extent"`
+	Scales          json.RawMessage                `json:"scales"`
+	TileResolutions []float64                      `json:"tile_resolutions"`
+	Formatters      []json.RawMessage              `json:"formatters,omitempty"`
+	Proj4           map[string]string              `json:"proj4,omitempty"`
+	Bookmarks       map[string]map[string]Bookmark `json:"bookmarks"`
 }


### PR DESCRIPTION
In QGIS, users can save bookmarks of extents. We can use these bookmarks in Gisquick projects.

PRs to support other parts of Gisquick (settings, plugin and client) will follow.