### PR TITLE
Language per project

### DIFF
--- a/internal/application/projects.go
+++ b/internal/application/projects.go
@@ -766,6 +766,7 @@ func (s *projectService) GetMapConfig(projectName string, user domain.User) (map
 	data["name"] = projectName
 	data["ows_url"] = fmt.Sprintf("/api/map/ows/%s", projectName)
 	data["ows_project"] = projectName
+	data["lang"] = settings.Language
 
 	topics := make([]domain.Topic, 0)
 

--- a/internal/domain/project_settings.go
+++ b/internal/domain/project_settings.go
@@ -70,4 +70,5 @@ type ProjectSettings struct {
 	TileResolutions []float64                `json:"tile_resolutions"`
 	Formatters      []json.RawMessage        `json:"formatters,omitempty"`
 	Proj4           map[string]string        `json:"proj4,omitempty"`
+	Language        string                   `json:"lang"`
 }

--- a/internal/server/project.go
+++ b/internal/server/project.go
@@ -71,6 +71,11 @@ func (s *Server) handleGetProject() func(c echo.Context) error {
 				data["notifications"] = messages
 			}
 		}
+
+		if data["lang"] == "" {
+			data["lang"] = s.Config.Language
+		}
+
 		data["status"] = 200
 		// delete(data, "layers")
 		// return c.JSON(http.StatusOK, data["layers"])


### PR DESCRIPTION
At the moment only one language can be set for the whole Gisquick instance. This PR adds server support for language setting per project.